### PR TITLE
Update Rust logo to non-black logo

### DIFF
--- a/data/code/languages_images.json
+++ b/data/code/languages_images.json
@@ -26,7 +26,7 @@
     "Python": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/500px-Python-logo-notext.svg.png",
     "Rill": "https://i.imgur.com/VagH89j.png",
     "Ruby": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Ruby_logo.svg/500px-Ruby_logo.svg.png",
-    "Rust": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Rust_programming_language_black_logo.svg/1200px-Rust_programming_language_black_logo.svg.png",
+    "Rust": "https://www.rust-lang.org/logos/rust-logo-512x512.png",
     "Scala": "https://i.imgur.com/5uBOncQ.png",
     "SQL": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Applications-database.svg/500px-Applications-database.svg.png",
     "Swift": "https://upload.wikimedia.org/wikipedia/fr/6/63/Logo_Apple_Swift.png",


### PR DESCRIPTION
Black logo on black background looks really bad, if you can see it.